### PR TITLE
Fix for the inscription changing, and a proposal.

### DIFF
--- a/src/main/java/taintedmagic/common/items/tools/ItemKatana.java
+++ b/src/main/java/taintedmagic/common/items/tools/ItemKatana.java
@@ -246,7 +246,7 @@ public class ItemKatana extends Item implements IWarpingGear, IRepairable, IRend
 			case 0 :
 			{
 				EntityExplosiveOrb proj = new EntityExplosiveOrb(w, p);
-				proj.strength = getAttackDamage(s) * 0.5F;
+				proj.strength = getAttackDamage(s) * 0.25F;
 				proj.posX += proj.motionX;
 				proj.posY += proj.motionY;
 				proj.posZ += proj.motionZ;
@@ -271,8 +271,6 @@ public class ItemKatana extends Item implements IWarpingGear, IRepairable, IRend
 				break;
 			}
 		}
-		s.stackTagCompound = new NBTTagCompound();
-		s.getTagCompound().setInteger("inscription", 1);
 	}
 
 	private boolean isFullyCharged (EntityPlayer p)


### PR DESCRIPTION
This should fix the problem I had that after casting the fireball of the volcanic inscription, after which the inscription changed to a tainted inscription.
Also, for the volcanic inscription, I would propose an explosion power of attack damage * 0.25, instead of 0.5, because with 0.5 that would mean an explosion power roughly equal to a wither explosion for the thaumium fortress blade, and even higher for the other two.