### PR TITLE
Add a keybind to toggle voidwalker's sash

### DIFF
--- a/src/main/java/taintedmagic/client/ClientProxy.java
+++ b/src/main/java/taintedmagic/client/ClientProxy.java
@@ -13,6 +13,7 @@ import net.minecraftforge.client.MinecraftForgeClient;
 import net.minecraftforge.common.MinecraftForge;
 import taintedmagic.client.handler.ClientHandler;
 import taintedmagic.client.handler.HUDHandler;
+import taintedmagic.client.handler.SashKeyListener;
 import taintedmagic.client.renderer.RenderEntityDiffusion;
 import taintedmagic.client.renderer.RenderEntityHomingShard;
 import taintedmagic.client.renderer.RenderItemKatana;
@@ -49,6 +50,7 @@ public class ClientProxy extends CommonProxy {
 
         FMLCommonHandler.instance().bus().register(new ClientHandler());
         MinecraftForge.EVENT_BUS.register(new ClientHandler());
+        MinecraftForge.EVENT_BUS.register(new SashKeyListener());
     }
 
     @Override

--- a/src/main/java/taintedmagic/client/handler/SashKeyListener.java
+++ b/src/main/java/taintedmagic/client/handler/SashKeyListener.java
@@ -1,0 +1,38 @@
+package taintedmagic.client.handler;
+
+import baubles.common.lib.PlayerHandler;
+import cpw.mods.fml.client.registry.ClientRegistry;
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.InputEvent;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.settings.KeyBinding;
+import net.minecraft.item.ItemStack;
+import org.lwjgl.input.Keyboard;
+import taintedmagic.common.items.equipment.ItemVoidwalkerSash;
+import taintedmagic.common.network.PacketHandler;
+import taintedmagic.common.network.PacketSashToggle;
+
+@SideOnly(Side.CLIENT)
+public class SashKeyListener {
+
+    private static final KeyBinding toggleSash = new KeyBinding("tmisc.toggleSash", Keyboard.CHAR_NONE, "tmisc.keyCategory");
+
+    public SashKeyListener() {
+        FMLCommonHandler.instance().bus().register(this);
+        ClientRegistry.registerKeyBinding(toggleSash);
+    }
+
+    @SubscribeEvent
+    public void keyUp(InputEvent.KeyInputEvent event) {
+        if (toggleSash.isPressed()) {
+
+            final ItemStack sash = PlayerHandler.getPlayerBaubles(Minecraft.getMinecraft().thePlayer).getStackInSlot(3);
+            if (sash != null && sash.getItem() instanceof ItemVoidwalkerSash) {
+                PacketHandler.INSTANCE.sendToServer(new PacketSashToggle());
+            }
+        }
+    }
+}

--- a/src/main/java/taintedmagic/common/items/equipment/ItemVoidwalkerBoots.java
+++ b/src/main/java/taintedmagic/common/items/equipment/ItemVoidwalkerBoots.java
@@ -137,7 +137,7 @@ public class ItemVoidwalkerBoots extends ItemArmor
 
             // speed boost
             if (player.onGround || player.capabilities.isFlying) {
-                float bonus = 0.12F;
+                float bonus = 0.15F;
                 final ItemStack sash = PlayerHandler.getPlayerBaubles(player).getStackInSlot(3);
                 if (sash != null && sash.getItem() instanceof ItemVoidwalkerSash && ItemVoidwalkerSash.isSpeedEnabled(sash)) {
                     bonus *= 2.0F;

--- a/src/main/java/taintedmagic/common/items/equipment/ItemVoidwalkerSash.java
+++ b/src/main/java/taintedmagic/common/items/equipment/ItemVoidwalkerSash.java
@@ -5,6 +5,8 @@ import java.util.List;
 import baubles.api.BaubleType;
 import baubles.api.IBauble;
 import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.EnumRarity;
@@ -91,34 +93,43 @@ public class ItemVoidwalkerSash extends ItemRunic implements IRunicArmor, IWarpi
 
     @Override
     public void onWornTick (final ItemStack stack, final EntityLivingBase entity) {
+        // ignore
     }
 
     @Override
     public ItemStack onItemRightClick (final ItemStack stack, final World world, final EntityPlayer player) {
-        if (!world.isRemote && player.isSneaking()) {
-            if (stack.stackTagCompound == null) {
-                stack.setTagCompound(new NBTTagCompound());
-                stack.stackTagCompound.setBoolean(TAG_MODE, true);
-            }
-            if (stack.stackTagCompound != null) {
-                stack.stackTagCompound.setBoolean(TAG_MODE, !stack.stackTagCompound.getBoolean(TAG_MODE));
-                if (isSpeedEnabled(stack)) {
-                    HUDHandler.displayString(EnumChatFormatting.GREEN + StatCollector.translateToLocal("text.sash.speed.on"),
-                            300, false);
-                }
-                else {
-                    HUDHandler.displayString(EnumChatFormatting.RED + StatCollector.translateToLocal("text.sash.speed.off"),
-                            300, false);
-                }
+        if (player.isSneaking()) {
+
+            toggleMode(stack);
+
+            if (world.isRemote) {
+                sendToggleNotification(stack);
             }
         }
         return stack;
     }
 
-    /**
-     * Returns true if the speed boost feature is enabled.
-     */
-    public static boolean isSpeedEnabled (final ItemStack stack) {
+    public static void toggleMode(ItemStack stack) {
+        if (stack.stackTagCompound == null) {
+            stack.setTagCompound(new NBTTagCompound());
+            stack.stackTagCompound.setBoolean(TAG_MODE, true);
+        } else {
+            stack.stackTagCompound.setBoolean(TAG_MODE, !stack.stackTagCompound.getBoolean(TAG_MODE));
+        }
+    }
+
+    @SideOnly(Side.CLIENT)
+    public static void sendToggleNotification(ItemStack stack) {
+        if (isSpeedEnabled(stack)) {
+            HUDHandler.displayString(EnumChatFormatting.GREEN + StatCollector.translateToLocal("text.sash.speed.on"),
+                    300, false);
+        } else {
+            HUDHandler.displayString(EnumChatFormatting.RED + StatCollector.translateToLocal("text.sash.speed.off"),
+                    300, false);
+        }
+    }
+
+    public static boolean isSpeedEnabled (final  ItemStack stack) {
         if (stack.stackTagCompound == null)
             return true;
         return stack.stackTagCompound.getBoolean(TAG_MODE);

--- a/src/main/java/taintedmagic/common/network/PacketHandler.java
+++ b/src/main/java/taintedmagic/common/network/PacketHandler.java
@@ -7,10 +7,14 @@ import taintedmagic.common.TaintedMagic;
 
 public class PacketHandler {
 
+    private PacketHandler() {}
+
     public static final SimpleNetworkWrapper INSTANCE =
             NetworkRegistry.INSTANCE.newSimpleChannel(TaintedMagic.MOD_ID.toLowerCase());
 
     public static void initPackets () {
         INSTANCE.registerMessage(PacketKatanaAttack.class, PacketKatanaAttack.class, 0, Side.SERVER);
+        INSTANCE.registerMessage(PacketSashToggle.class, PacketSashToggle.class, 1, Side.SERVER);
+        INSTANCE.registerMessage(PacketSashToggleAck.class, PacketSashToggleAck.class, 2, Side.CLIENT);
     }
 }

--- a/src/main/java/taintedmagic/common/network/PacketSashToggle.java
+++ b/src/main/java/taintedmagic/common/network/PacketSashToggle.java
@@ -1,0 +1,40 @@
+package taintedmagic.common.network;
+
+import baubles.common.container.InventoryBaubles;
+import baubles.common.lib.PlayerHandler;
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
+import taintedmagic.common.items.equipment.ItemVoidwalkerSash;
+
+public class PacketSashToggle implements IMessage, IMessageHandler<PacketSashToggle, IMessage> {
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        // do nothing
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        // do nothing
+    }
+
+    @Override
+    public IMessage onMessage(PacketSashToggle message, MessageContext ctx) {
+        EntityPlayerMP player = ctx.getServerHandler().playerEntity;
+
+        final InventoryBaubles inventoryBaubles = PlayerHandler.getPlayerBaubles(player);
+        final int beltSlot = 3;
+        final ItemStack sash = inventoryBaubles.getStackInSlot(beltSlot);
+        if (sash != null && sash.getItem() instanceof ItemVoidwalkerSash) {
+            ItemVoidwalkerSash.toggleMode(sash);
+            inventoryBaubles.syncSlotToClients(beltSlot);
+            PacketHandler.INSTANCE.sendTo(new PacketSashToggleAck(), player);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/taintedmagic/common/network/PacketSashToggleAck.java
+++ b/src/main/java/taintedmagic/common/network/PacketSashToggleAck.java
@@ -1,0 +1,37 @@
+package taintedmagic.common.network;
+
+import baubles.common.lib.PlayerHandler;
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import taintedmagic.common.TaintedMagic;
+import taintedmagic.common.items.equipment.ItemVoidwalkerSash;
+
+public class PacketSashToggleAck implements IMessage, IMessageHandler<PacketSashToggleAck, IMessage> {
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        // do nothing
+    }
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        // do nothing
+    }
+
+    @Override
+    public IMessage onMessage(PacketSashToggleAck message, MessageContext ctx) {
+        EntityPlayer player = TaintedMagic.proxy.getClientPlayer();
+
+        final int beltSlot = 3;
+        final ItemStack sash = PlayerHandler.getPlayerBaubles(player).getStackInSlot(beltSlot);
+        if (sash != null && sash.getItem() instanceof ItemVoidwalkerSash) {
+            ItemVoidwalkerSash.sendToggleNotification(sash);
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Running around your base at high speed can sometimes be annoying, even more annoying is when you have to open your baubles to toggle sash by right clicking it. It also buffs sash speed bonus since it is barely visible.